### PR TITLE
Use new python 3.10 version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set ENV Variables
         run: |
           IMG="$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
-          echo "BUILD_VER=debian-11-slim" >> $GITHUB_ENV
+          echo "BUILD_VER=$(cat Dockerfile | grep 'ENV PY_VERSION' | cut -d " " -f 3)" >> $GITHUB_ENV
           echo "IMAGE=${IMG}" >> $GITHUB_ENV
           echo "GIT_SHA=$$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:11-slim
 ENV DEBIAN_FRONTEND noninteractive
+ENV PY_VERSION 3.10.4
 ENV TZ UTC
 RUN apt-get update \
     && apt-get upgrade --yes \
@@ -20,16 +21,16 @@ RUN apt-get update \
     zlib1g-dev \
     libssl-dev \
     && cd ~ \
-    && wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
-    && tar -xvf Python-3.10.4.tgz \
-    && cd Python-3.10.4 \
+    && wget https://www.python.org/ftp/python/${PY_VERSION}/Python-${PY_VERSION}.tgz \
+    && tar -xvf Python-${PY_VERSION}.tgz \
+    && cd Python-${PY_VERSION} \
     && ./configure --prefix=/usr/local --enable-optimizations \
     && make -j $(nproc) \
     && make install \
     && ln -s /usr/local/bin/python3 /usr/local/bin/python \
     && ln -s /usr/local/bin/pip3 /usr/local/bin/pip \
     && cd .. \
-    && rm -rf Python-3.* \
+    && rm -rf Python-{$PY_VERSION} \
     && curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | apt-key add - \
     && echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" | tee /etc/apt/sources.list.d/doppler-cli.list \
     && python3 -m venv /venv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ ENV TZ UTC
 RUN apt-get update \
     && apt-get upgrade --yes \
     && apt-get install --no-install-suggests --no-install-recommends --yes \
-    python3-venv \
     gcc \
-    libpython3-dev \
     g++ \
     wget \
     curl \
@@ -19,11 +17,31 @@ RUN apt-get update \
     apt-transport-https \
     ca-certificates \
     gnupg \
+    zlib1g-dev \
+    libssl-dev \
+    build-essential \
+    libbz2-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    llvm \
+    libncurses5-dev \
+    libncursesw5-dev \
+    tk-dev \
+    && cd ~ \
+    && wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
+    && tar -xvf Python-3.10.4.tgz \
+    && cd Python-3.10.4 \
+    && ./configure --prefix=/usr/local --enable-optimizations \
+    && make -j $(nproc) \
+    && make install \
+    && ln -s /usr/local/bin/python3 /usr/local/bin/python \
+    && ln -s /usr/local/bin/pip3 /usr/local/bin/pip \
+    && cd .. \
+    && rm -rf Python-3.* \
     && curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | apt-key add - \
     && echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" | tee /etc/apt/sources.list.d/doppler-cli.list \
     && python3 -m venv /venv \
-    && /venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel poetry==1.1.13 \
+    && /venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel poetry \
     && apt-get clean \
     && apt-get autoremove --purge \
     && rm -rf /var/lib/apt/lists/* /root/* /tmp/* /var/cache/apt/archives/*.deb
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,6 @@ RUN apt-get update \
     gnupg \
     zlib1g-dev \
     libssl-dev \
-    build-essential \
-    libbz2-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    llvm \
-    libncurses5-dev \
-    libncursesw5-dev \
-    tk-dev \
     && cd ~ \
     && wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz \
     && tar -xvf Python-3.10.4.tgz \
@@ -43,5 +35,5 @@ RUN apt-get update \
     && python3 -m venv /venv \
     && /venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel poetry \
     && apt-get clean \
-    && apt-get autoremove --purge \
+    && apt-get autoremove --purge --yes \
     && rm -rf /var/lib/apt/lists/* /root/* /tmp/* /var/cache/apt/archives/*.deb


### PR DESCRIPTION
The image will now also build the latest python version instead of downloading the pre-built one from apt repositories.