### PR TITLE
Use official python docker image for base

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set ENV Variables
         run: |
           IMG="$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
-          echo "BUILD_VER=$(cat Dockerfile | grep 'ENV PY_VERSION' | cut -d " " -f 3)" >> $GITHUB_ENV
+          echo "BUILD_VER=$(cat Dockerfile | grep 'FROM python:' | cut -d ":" -f 2 | cut -d "-" -f 1)" >> $GITHUB_ENV
           echo "IMAGE=${IMG}" >> $GITHUB_ENV
           echo "GIT_SHA=$$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
           echo "BUILD_DATE=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM debian:11-slim
+FROM python:3.10.4-slim
 ENV DEBIAN_FRONTEND noninteractive
-ENV PY_VERSION 3.10.4
 ENV TZ UTC
 RUN apt-get update \
     && apt-get upgrade --yes \
@@ -18,19 +17,6 @@ RUN apt-get update \
     apt-transport-https \
     ca-certificates \
     gnupg \
-    zlib1g-dev \
-    libssl-dev \
-    && cd ~ \
-    && wget https://www.python.org/ftp/python/${PY_VERSION}/Python-${PY_VERSION}.tgz \
-    && tar -xvf Python-${PY_VERSION}.tgz \
-    && cd Python-${PY_VERSION} \
-    && ./configure --prefix=/usr/local --enable-optimizations \
-    && make -j $(nproc) \
-    && make install \
-    && ln -s /usr/local/bin/python3 /usr/local/bin/python \
-    && ln -s /usr/local/bin/pip3 /usr/local/bin/pip \
-    && cd .. \
-    && rm -rf Python-{$PY_VERSION} \
     && curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | apt-key add - \
     && echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" | tee /etc/apt/sources.list.d/doppler-cli.list \
     && python3 -m venv /venv \


### PR DESCRIPTION
Official image greatly reduces size and will always use latest docker version